### PR TITLE
Ajusta cálculo da energia cinética na dinâmica

### DIFF
--- a/calcularDinamica.m
+++ b/calcularDinamica.m
@@ -40,7 +40,7 @@ function Dinamica = calcularDinamica(Pcm)
         dq             = Pcm{i}.juntas(2,:);
         Iaux           = Pcm{i}.T(1:3,1:3) * I(i) * Pcm{i}.T(1:3,1:3);
         Dinamica.Ep(i) = (Massa(i)) * Dinamica.gravidade * (Pcm{i}.P);
-        Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (Massa(i)/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
+        Dinamica.Ec(i) = 0.5 * Massa(i) * transpose(Pcm{i}.V) * Pcm{i}.V + 0.5 * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
     end
 
     Dinamica.Lagrangeano = -Dinamica.EcT + Dinamica.EpT;


### PR DESCRIPTION
## Summary
- corrige a expressão da energia cinética para usar 0.5*M*vᵀv + 0.5*wᵀIauxw
- mantém o uso de Iaux como tensor transformado para a base inercial

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfca5ef420832b958db668a4c8eaee