### PR TITLE
Fix gravity torque computation to use total energies

### DIFF
--- a/calcularDinamica.m
+++ b/calcularDinamica.m
@@ -2,7 +2,7 @@ function Dinamica = calcularDinamica(Pcm)
     syms g
 
     
-    n = Pcm{6}.n;
+    n = Pcm{end}.n;
     syms Massa [1,n]
     syms Ixx   [n,1]
     syms Ixy   [n,1]
@@ -22,7 +22,6 @@ function Dinamica = calcularDinamica(Pcm)
     end
     
 
-    H1_aux             = sym(zeros(n,1));    
     Dinamica           = struct();
     Dinamica.G         = sym(zeros(n,1));
     Dinamica.M         = sym(zeros(n,n));
@@ -34,26 +33,33 @@ function Dinamica = calcularDinamica(Pcm)
     Dinamica.EpT       = 0;
     Dinamica.gravidade = [0 0 g];
 
-    
+    q  = Pcm{end}.juntas(1,:);
+    dq = Pcm{end}.juntas(2,:);
+
     for i = 1:n
-        q              = Pcm{i}.juntas(1,:);
-        dq             = Pcm{i}.juntas(2,:);
         Iaux           = Pcm{i}.T(1:3,1:3) * I(i) * Pcm{i}.T(1:3,1:3);
         Dinamica.Ep(i) = (Massa(i)) * Dinamica.gravidade * (Pcm{i}.P);
         Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (Massa(i)/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
+        Dinamica.EpT   = Dinamica.EpT + Dinamica.Ep(i);
+        Dinamica.EcT   = Dinamica.EcT + Dinamica.Ec(i);
     end
 
     Dinamica.Lagrangeano = -Dinamica.EcT + Dinamica.EpT;
 
     for i = 1:n
-        Dinamica.G(i,1)  =  diff(Dinamica.Ep(i),q(i));
-        Dinamica.H2(i,1) = -diff(Dinamica.Ec(i),q(i));
-        for j = 1:n
-            Dinamica.M(i,j) = diff(diff(Dinamica.Ec(i),dq(i)),dq(j));
-            H1_aux(j,1) = diff(diff(Dinamica.Ec(i),dq(i)),q(j))*dq(j);
+        Dinamica.G(i,1) = 0;
+        for k = 1:n
+            Dinamica.G(i,1) = Dinamica.G(i,1) + diff(Dinamica.Ep(k), q(i));
         end
 
-        Dinamica.H1(i,1) = sum(H1_aux);
+        Dinamica.H2(i,1) = -diff(Dinamica.EcT, q(i));
+        H1_sum = sym(0);
+        for j = 1:n
+            Dinamica.M(i,j) = diff(diff(Dinamica.Ec(i),dq(i)),dq(j));
+            H1_sum = H1_sum + diff(diff(Dinamica.EcT, dq(i)), q(j)) * dq(j);
+        end
+
+        Dinamica.H1(i,1) = H1_sum;
     end
 
     Dinamica.H = Dinamica.H1 + Dinamica.H2;

--- a/test_gravity_symbolic.m
+++ b/test_gravity_symbolic.m
@@ -1,0 +1,43 @@
+function test_gravity_symbolic()
+%TEST_GRAVITY_SYMBOLIC Verifica se os torques gravitacionais aparecem nas
+%juntas de base para um manipulador planar simples com dois elos.
+
+    ordem = {'y','y'};
+    excentricidades = [1 0 0; 1 0 0];
+
+    robo = calcularTransformadas(ordem, excentricidades);
+    cin = calcularCinematicaTotal(robo);
+
+    Dinamica = calcularDinamica(cin);
+
+    subsVars = {
+        sym('Q1'),   sym('Q2'), ...
+        sym('dQ1'),  sym('dQ2'), ...
+        sym('d2Q1'), sym('d2Q2'), ...
+        sym('Lx1'),  sym('Lx2'), ...
+        sym('Lxcm1'), sym('Lxcm2'), ...
+        sym('Lycm1'), sym('Lycm2'), ...
+        sym('Lzcm1'), sym('Lzcm2'), ...
+        sym('Massa1'), sym('Massa2'), ...
+        sym('g')
+    };
+
+    vals = {
+        0.3,  -0.2, ...   % posições articulares
+        0.0,   0.0, ...   % velocidades articulares
+        0.0,   0.0, ...   % acelerações articulares
+        0.5,   0.4, ...   % comprimentos dos elos
+        0.25,  0.2, ...   % centros de massa ao longo de X
+        0.0,   0.0, ...   % centros de massa ao longo de Y
+        0.0,   0.0, ...   % centros de massa ao longo de Z
+        1.5,   1.0, ...   % massas
+        9.81              % gravidade
+    };
+
+    Gval = double(subs(Dinamica.G, subsVars, vals));
+
+    assert(abs(Gval(1)) > 1.0e-6, ...
+        'O torque gravitacional na junta de base deve ser diferente de zero.');
+    assert(abs(Gval(2)) > 1.0e-6, ...
+        'O torque gravitacional na segunda junta deve ser diferente de zero.');
+end


### PR DESCRIPTION
## Summary
- accumulate the total potential and kinetic energies while building the dynamics structure
- compute the gravity, H1 and H2 vectors from the total energies so all links contribute to each joint
- add a symbolic regression test that validates gravity torques on the base joints of a two-link manipulator

## Testing
- not run (MATLAB/Octave not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfca62c6ec832bbf64181f4db6034b