### PR TITLE
Ajusta termo rotacional da energia cinética

### DIFF
--- a/calcularDinamica.m
+++ b/calcularDinamica.m
@@ -40,7 +40,7 @@ function Dinamica = calcularDinamica(Pcm)
         dq             = Pcm{i}.juntas(2,:);
         Iaux           = Pcm{i}.T(1:3,1:3) * I(i) * Pcm{i}.T(1:3,1:3);
         Dinamica.Ep(i) = (Massa(i)) * Dinamica.gravidade * (Pcm{i}.P);
-        Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (Massa(i)/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
+        Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (1/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
     end
 
     Dinamica.Lagrangeano = -Dinamica.EcT + Dinamica.EpT;


### PR DESCRIPTION
## Summary
- remove o fator de massa do termo rotacional na energia cinética calculada em `calcularDinamica`

## Testing
- not run (Matlab/Octave indisponível no ambiente)


------
https://chatgpt.com/codex/tasks/task_e_68cfcf994ed4832b9386797b2aa4c258