### PR TITLE
Fix inertia tensor cell access in calcularDinamica

### DIFF
--- a/calcularDinamica.m
+++ b/calcularDinamica.m
@@ -38,7 +38,7 @@ function Dinamica = calcularDinamica(Pcm)
     for i = 1:n
         q              = Pcm{i}.juntas(1,:);
         dq             = Pcm{i}.juntas(2,:);
-        Iaux           = Pcm{i}.T(1:3,1:3) * I(i) * Pcm{i}.T(1:3,1:3);
+        Iaux           = Pcm{i}.T(1:3,1:3) * I{i} * Pcm{i}.T(1:3,1:3).';
         Dinamica.Ep(i) = (Massa(i)) * Dinamica.gravidade * (Pcm{i}.P);
         Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (Massa(i)/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
     end


### PR DESCRIPTION
## Summary
- update the inertia tensor assembly to pull symbolic tensors from the cell array
- multiply by the transpose of the rotation submatrix when forming Iaux

## Testing
- not run (Matlab/Octave environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfcf9ac7bc832b899d7669a8bfebee