### PR TITLE
Atualiza energia cinética e validação da matriz de inércia

### DIFF
--- a/calcularDinamica.m
+++ b/calcularDinamica.m
@@ -40,7 +40,7 @@ function Dinamica = calcularDinamica(Pcm)
         dq             = Pcm{i}.juntas(2,:);
         Iaux           = Pcm{i}.T(1:3,1:3) * I(i) * Pcm{i}.T(1:3,1:3);
         Dinamica.Ep(i) = (Massa(i)) * Dinamica.gravidade * (Pcm{i}.P);
-        Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (Massa(i)/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
+        Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (1/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
     end
 
     Dinamica.Lagrangeano = -Dinamica.EcT + Dinamica.EpT;

--- a/sanity_check.m
+++ b/sanity_check.m
@@ -94,8 +94,37 @@ Gnum = double(subs(Dcm.Torque.G, subsD, valsD));
 fprintf('\n||M - M^T||_F = %.3e\n', norm(Mnum - Mnum.', 'fro'));
 fprintf('Norma de G: %.3e\n', norm(Gnum));
 
+% Referência independente da matriz de inércia usando func_M (gerada simbolicamente)
+args_func_M = [
+    num2cell(Ival(2:6).'), ...                                      % Ixx2..Ixx6
+    num2cell(zeros(1,5)), ...                                       % Ixy2..Ixy6
+    num2cell(zeros(1,5)), ...                                       % Ixz2..Ixz6
+    num2cell(zeros(1,5)), ...                                       % Iyx2..Iyx6
+    num2cell(Ival(2:6).'), ...                                      % Iyy2..Iyy6
+    num2cell(zeros(1,5)), ...                                       % Iyz2..Iyz6
+    num2cell(zeros(1,5)), ...                                       % Izx2..Izx6
+    num2cell(zeros(1,5)), ...                                       % Izy2..Izy6
+    num2cell(Ival.'), ...                                           % Izz1..Izz6
+    num2cell(Lvals(2:3,1).'), ...                                   % Lx2, Lx3
+    num2cell(LcmVals(:,1).'), ...                                   % Lxcm1..Lxcm6
+    num2cell(LcmVals(:,2).'), ...                                   % Lycm1..Lycm6
+    num2cell(Lvals(4:5,3).'), ...                                   % Lz4, Lz5
+    num2cell(LcmVals(2:6,3).'), ...                                 % Lzcm2..Lzcm6
+    num2cell(Qv), ...                                               % Q1..Q6
+    num2cell(mval) ...                                              % m1..m6
+];
+
+Mref = func_M(args_func_M{:});
+fprintf('||M - M_ref(func\\_M)||_F = %.3e\n', norm(Mnum - Mref, 'fro'));
+
 if norm(Mnum - Mnum.', 'fro') < 1e-8
     disp('✅ M simétrica (ok)');
 else
     warning('⚠️  M não está exatamente simétrica — verifique as expressões.');
+end
+
+if norm(Mnum - Mref, 'fro') < 1e-8
+    disp('✅ M coincide com func_M (ok)');
+else
+    warning('⚠️  Discrepância entre M e func_M — verifique os termos de inércia.');
 end


### PR DESCRIPTION
## Summary
- remove o fator de massa extra do termo rotacional da energia cinética em `calcularDinamica`
- amplia `sanity_check` para comparar a matriz M obtida com a referência analítica de `func_M`

## Testing
- não executado (MATLAB/Octave indisponível no ambiente)


------
https://chatgpt.com/codex/tasks/task_e_68cfe683cc60832ba6630bf760c13843