### PR TITLE
Corrige transformação de inércia na dinâmica

### DIFF
--- a/calcularDinamica.m
+++ b/calcularDinamica.m
@@ -38,7 +38,8 @@ function Dinamica = calcularDinamica(Pcm)
     for i = 1:n
         q              = Pcm{i}.juntas(1,:);
         dq             = Pcm{i}.juntas(2,:);
-        Iaux           = Pcm{i}.T(1:3,1:3) * I(i) * Pcm{i}.T(1:3,1:3);
+        R              = Pcm{i}.T(1:3,1:3);
+        Iaux           = R * I{i} * R.';
         Dinamica.Ep(i) = (Massa(i)) * Dinamica.gravidade * (Pcm{i}.P);
         Dinamica.Ec(i) = (Massa(i)/2) * transpose(Pcm{i}.V) * Pcm{i}.V + (Massa(i)/2) * transpose(Pcm{i}.W) * Iaux * (Pcm{i}.W);
     end


### PR DESCRIPTION
## Summary
- utiliza a matriz de rotação `Pcm{i}.T(1:3,1:3)` para transformar corretamente a inércia em cada elo.
- garante o uso da célula `I{i}` na multiplicação de inércia.

## Testing
- python - <<'PY'
import math

def matmul(A, B):
    return [[sum(A[i][k]*B[k][j] for k in range(len(B))) for j in range(len(B[0]))] for i in range(len(A))]

def transpose(A):
    return [list(row) for row in zip(*A)]

I = [[1.0, 0.2, -0.1], [0.2, 2.0, 0.3], [-0.1, 0.3, 3.0]]
angle = math.pi/7
R = [
    [math.cos(angle), -math.sin(angle), 0.0],
    [math.sin(angle),  math.cos(angle), 0.0],
    [0.0,              0.0,             1.0],
]
RI = matmul(R, I)
Iaux = matmul(RI, transpose(R))
Iaux_T = transpose(Iaux)
max_diff = max(abs(Iaux[i][j] - Iaux_T[i][j]) for i in range(3) for j in range(3))
print(f"Maximum absolute asymmetry: {max_diff:.12f}")
PY

------
https://chatgpt.com/codex/tasks/task_e_68cfe6878b7c832bab57d64edeab1085